### PR TITLE
Fix env sourcing in automation script

### DIFF
--- a/run_full_automation.sh
+++ b/run_full_automation.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
-# Load environment variables properly
+# Determine the directory of this script so relative paths work even when the
+# script is called from elsewhere.
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+
+# Load environment variables from the .env file located in the script's directory
 set -a
-source /home/doug/WDN-auto-blog-posts/.env
+source "$SCRIPT_DIR/.env"
 set +a
 
 # Debugging - Print loaded credentials


### PR DESCRIPTION
## Summary
- compute the directory of `run_full_automation.sh`
- source the `.env` file from that directory instead of a hard-coded path

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_684075a103ec8331b8fabd569af41d38